### PR TITLE
Improved Circle Drawing Algorithm.

### DIFF
--- a/src/screen.jl
+++ b/src/screen.jl
@@ -161,6 +161,7 @@ sdl_colors(c::ARGB) = Int.(reinterpret.((red(c), green(c), blue(c), alpha(c))))
 
 # improved circle drawing algorithm. slower but fills completely. needs optimization
 function draw(s::Screen, circle::Circle, c::Colorant=colorant"black"; fill=false)
+    # define the center and needed sides of circle
     centerX = Cint(circle.x)
     centerY = Cint(circle.y)
     int_rad = Cint(circle.r)
@@ -172,10 +173,14 @@ function draw(s::Screen, circle::Circle, c::Colorant=colorant"black"; fill=false
         sdl_colors(c)...,
     )
 
+    # we consider a grid with sides equal to the circle's diameter
     for x in left:centerX
         for y in top:centerY
 
+            # for each pixel in the top left quadrant of the grid we measure the distance from the center.
             dist = sqrt( (centerX - x)^2 + (centerY - y)^2 )
+
+            # if it is close to the circle's radius it and all associated points in the other quadrants are colored in.
             if (dist <= circle.r + 0.5 && dist >= circle.r - 0.5)
                 rel_x = centerX - x
                 rel_y = centerY - y
@@ -190,6 +195,7 @@ function draw(s::Screen, circle::Circle, c::Colorant=colorant"black"; fill=false
                 SDL2.RenderDrawPoint(s.renderer, quad3[1], quad3[2])
                 SDL2.RenderDrawPoint(s.renderer, quad4[1], quad4[2])
 
+                # if we are told to fill in the circle we draw lines between all of the quadrants to completely fill the circle
                 if (fill == true)
                     SDL2.RenderDrawLine(s.renderer, quad1[1], quad1[2], quad2[1], quad2[2])
                     SDL2.RenderDrawLine(s.renderer, quad2[1], quad2[2], quad4[1], quad4[2])

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -159,58 +159,48 @@ end
 sdl_colors(c::Colorant) = sdl_colors(convert(ARGB{Colors.FixedPointNumbers.Normed{UInt8,8}}, c))
 sdl_colors(c::ARGB) = Int.(reinterpret.((red(c), green(c), blue(c), alpha(c))))
 
-#Naive Algorithm, should be improved.
+# improved circle drawing algorithm. slower but fills completely. needs optimization
 function draw(s::Screen, circle::Circle, c::Colorant=colorant"black"; fill=false)
+    centerX = Cint(circle.x)
+    centerY = Cint(circle.y)
+    int_rad = Cint(circle.r)
+    left = centerX - int_rad
+    top = centerY - int_rad
 
     SDL2.SetRenderDrawColor(
         s.renderer,
         sdl_colors(c)...,
     )
-    diameter = Cint(round(circle.r * 2));
 
-    centreX = Cint(round(circle.x))
-    centreY = Cint(round(circle.y))
+    for x in left:centerX
+        for y in top:centerY
 
-    x = Cint(round(circle.r - 1))
-    y = Cint(0)
-    tx = Cint(1)
-    ty = Cint(1)
-    error = (tx - diameter)
+            dist = sqrt( (centerX - x)^2 + (centerY - y)^2 )
+            if (dist <= circle.r + 0.5 && dist >= circle.r - 0.5)
+                rel_x = centerX - x
+                rel_y = centerY - y
 
-    while (x >= y)
-        #Each of the following renders an eight of the circle
-        if !fill
-            SDL2.RenderDrawPoint(s.renderer, centreX + x, centreY - y);
-            SDL2.RenderDrawPoint(s.renderer, centreX + x, centreY + y);
-            SDL2.RenderDrawPoint(s.renderer, centreX - x, centreY - y);
-            SDL2.RenderDrawPoint(s.renderer, centreX - x, centreY + y);
-            SDL2.RenderDrawPoint(s.renderer, centreX + y, centreY - x);
-            SDL2.RenderDrawPoint(s.renderer, centreX + y, centreY + x);
-            SDL2.RenderDrawPoint(s.renderer, centreX - y, centreY - x);
-            SDL2.RenderDrawPoint(s.renderer, centreX - y, centreY + x);
-        else
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX + x, centreY - y);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX + x, centreY + y);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX - x, centreY - y);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX - x, centreY + y);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX + y, centreY - x);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX + y, centreY + x);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX - y, centreY - x);
-            SDL2.RenderDrawLine(s.renderer, centreX, centreY, centreX - y, centreY + x);
+                quad1 = (x              , y              )
+                quad2 = (centerX + rel_x, y              )
+                quad3 = (x              , centerY + rel_y)
+                quad4 = (quad2[1]       , quad3[2]       )
+
+                SDL2.RenderDrawPoint(s.renderer, quad1[1], quad1[2])
+                SDL2.RenderDrawPoint(s.renderer, quad2[1], quad2[2])
+                SDL2.RenderDrawPoint(s.renderer, quad3[1], quad3[2])
+                SDL2.RenderDrawPoint(s.renderer, quad4[1], quad4[2])
+
+                if (fill == true)
+                    SDL2.RenderDrawLine(s.renderer, quad1[1], quad1[2], quad2[1], quad2[2])
+                    SDL2.RenderDrawLine(s.renderer, quad2[1], quad2[2], quad4[1], quad4[2])
+                    SDL2.RenderDrawLine(s.renderer, quad4[1], quad4[2], quad3[1], quad3[2])
+                    SDL2.RenderDrawLine(s.renderer, quad3[1], quad3[2], quad1[1], quad1[2])
+                end
+            end
+
         end
+    end
 
-        if (error <= 0)
-            y += Cint(1)
-            error += ty
-            ty += Cint(2)
-        end
-
-        if (error > 0)
-            x -= Cint(1)
-            tx += Cint(2)
-            error += (tx - diameter)
-        end
-  end
 end
 
 rect(x::Rect) = x


### PR DESCRIPTION
This new circle drawing algorithm completely fills in the circle, and as far as I know it works for all sizes of circles. It tends to be only about 2x - 3x slower than the previous algorithm. There has been an anomaly with it where there is a small bump on the top of the circle that looks about a pixel high, but other than that there appears to be no problems. The strange bump only occurs when `fill=true` though. Here are some pictures of the results.
![circle_bump_prob2](https://user-images.githubusercontent.com/69170509/95028408-4f793200-065d-11eb-85f0-7c7593162660.png)
![circle_bump_prob](https://user-images.githubusercontent.com/69170509/95028456-9535fa80-065d-11eb-879a-a0cf30ffcd81.png)
![circle_nofill](https://user-images.githubusercontent.com/69170509/95028458-97985480-065d-11eb-92cb-8db9660d3296.png)