### PR TITLE
patch draw(a::Actor) function

### DIFF
--- a/src/actor.jl
+++ b/src/actor.jl
@@ -71,7 +71,9 @@ function draw(a::Actor)
         Ref(SDL2.Rect(r.x, r.y, w′, h′)),
         a.angle,
         C_NULL,
-        UInt32(0) )
+        UInt32(0) 
+    )
+    SDL2.DestroyTexture(texture)
 end
 
 """Angle to the horizontal, of the line between two actors, in degrees"""


### PR DESCRIPTION
Update draw(a::Actor) method to use `SDL2.DestroyTexture` on generated textures after they have been rendered. Should address https://github.com/aviks/GameZero.jl/issues/15