### PR TITLE
Fix mouse down event stucture

### DIFF
--- a/src/GameZero.jl
+++ b/src/GameZero.jl
@@ -172,8 +172,8 @@ getKeyRepeat(e) = bitcat(UInt8, e[14:-1:14])
 getKeyMod(e) = bitcat(UInt16, e[26:-1:25])
 
 getMouseButtonClick(e) = bitcat(UInt8, e[17:-1:17])
-getMouseClickX(e) = bitcat(Int32, e[23:-1:20])
-getMouseClickY(e) = bitcat(Int32, e[27:-1:24])
+getMouseClickX(e) =  bitcat(Int32, e[24:-1:21])
+getMouseClickY(e) = bitcat(Int32, e[28:-1:25])
 
 getMouseMoveX(e) = bitcat(Int32, e[24:-1:21])
 getMouseMoveY(e) = bitcat(Int32, e[28:-1:25])


### PR DESCRIPTION
There is a padding byte in the SDL_MouseButtonEvent [struct](https://github.com/SDL-mirror/SDL/blob/5f560547596381c62bc8c632cffd0b498adbff22/include/SDL_events.h#L271-L283), which is not in the [docs](https://wiki.libsdl.org/SDL_MouseButtonEvent). This is just making GameZero not index the wrong bytes.