### PR TITLE
Added game_include to allow for the inclusion of other files.

### DIFF
--- a/example/BasicGame/basic.jl
+++ b/example/BasicGame/basic.jl
@@ -48,7 +48,6 @@ function update(g::Game)
         dx = 2
     end
 
-
 end
 
 # If the "space" key is pressed, change the displayed image to the "hurt" variant. 

--- a/src/GameZero.jl
+++ b/src/GameZero.jl
@@ -3,7 +3,7 @@ using Colors
 using Random
 
 export Actor, Game, game, draw, schduler, schedule_once, schedule_interval, schedule_unique, unschedule,
-        collide, angle, distance, play_music, play_sound, line, clear, rungame
+        collide, angle, distance, play_music, play_sound, line, clear, rungame, game_include
 export Keys, MouseButtons, KeyMods
 export Line, Rect, Circle
 
@@ -73,6 +73,7 @@ end
 
 
 getifdefined(m, s, v) = isdefined(m, s) ? getfield(m, s) : v
+
 
 mainloop(g::Ref{Game}) = mainloop(g[])
 
@@ -224,7 +225,9 @@ function initgame(jlf::String)
     g.screen = initscreen(game_module, "GameZero::"*name)
     clear(g.screen)
     return g
-end 
+end
+
+game_include(jlf::String) = Base.include(game[].game_module, jlf)
 
 
 function getfn(m::Module, s::Symbol, maxargs=3)


### PR DESCRIPTION
The way that the game is currently running makes it so that you cannot include other files using julia's built in `include("foo.jl")`. This PR is a patch for that that creates the function `game_include` to get around this. It will run any wanted inclusion that is done in the form `game_include("foo.jl")`. This is a somewhat hacky workaround, but it works just fine until we can find a better way to run the game.