### PR TITLE
Changed the way games are run.

### DIFF
--- a/example/BasicGame/basic.jl
+++ b/example/BasicGame/basic.jl
@@ -48,7 +48,6 @@ function update(g::Game)
         dx = 2
     end
 
-
 end
 
 # If the "space" key is pressed, change the displayed image to the "hurt" variant. 

--- a/src/GameZero.jl
+++ b/src/GameZero.jl
@@ -3,7 +3,7 @@ using Colors
 using Random
 
 export Actor, Game, game, draw, schduler, schedule_once, schedule_interval, schedule_unique, unschedule,
-        collide, angle, distance, play_music, play_sound, line, clear, rungame
+        collide, angle, distance, play_music, play_sound, line, clear, rungame, game_include
 export Keys, MouseButtons, KeyMods
 export Line, Rect, Circle
 
@@ -73,6 +73,7 @@ end
 
 
 getifdefined(m, s, v) = isdefined(m, s) ? getfield(m, s) : v
+
 
 mainloop(g::Ref{Game}) = mainloop(g[])
 
@@ -224,7 +225,9 @@ function initgame(jlf::String)
     g.screen = initscreen(game_module, "GameZero::"*name)
     clear(g.screen)
     return g
-end 
+end
+
+game_include(jlf::String) = Base.include(game[].game_module, jlf)
 
 
 function getfn(m::Module, s::Symbol, maxargs=3)

--- a/src/GameZero.jl
+++ b/src/GameZero.jl
@@ -22,6 +22,7 @@ include("actor.jl")
 const HEIGHTSYMBOL = :HEIGHT
 const WIDTHSYMBOL = :WIDTH
 const BACKSYMBOL = :BACKGROUND
+const LOCATION = pwd()
 
 
 

--- a/src/GameZero.jl
+++ b/src/GameZero.jl
@@ -3,7 +3,7 @@ using Colors
 using Random
 
 export Actor, Game, game, draw, schduler, schedule_once, schedule_interval, schedule_unique, unschedule,
-        collide, angle, distance, play_music, play_sound, line, clear, rungame
+        collide, angle, distance, play_music, play_sound, line, clear, rungame, game_include
 export Keys, MouseButtons, KeyMods
 export Line, Rect, Circle
 
@@ -73,6 +73,8 @@ end
 
 
 getifdefined(m, s, v) = isdefined(m, s) ? getfield(m, s) : v
+
+game_include(jlf::String) = Base.include(game[].game_module, jlf)
 
 
 mainloop(g::Ref{Game}) = mainloop(g[])
@@ -220,12 +222,12 @@ function initgame(jlf::String, external::Bool)
         g.game_module = Main 
     end
 
-    # Base.include_string(g.game_module, "using GameZero")
-    # Base.include_string(g.game_module, "import GameZero.draw")
-    # Base.include_string(g.game_module, "using Colors")
-    # Base.include(g.game_module, jlf)
-
-    if external Base.include(g.game_module, jlf) end
+    if external
+        Base.include_string(g.game_module, "using GameZero")
+        Base.include_string(g.game_module, "import GameZero.draw")
+        Base.include_string(g.game_module, "using Colors")
+        Base.include(g.game_module, jlf)
+    end
 
     g.update_function = getfn(g.game_module, :update, 2)
     g.render_function = getfn(g.game_module, :draw, 1)

--- a/src/resources.jl
+++ b/src/resources.jl
@@ -42,7 +42,7 @@ function image_surface(image::String)
 end
 
 function file_path(name::String, subdir::Symbol)
-    path = joinpath(game[].location, String(subdir))
+    path = joinpath(LOCATION, String(subdir))
     @assert isdir(path)
     allfiles = readdir(path)
     allexts = resource_ext[subdir]


### PR DESCRIPTION
This PR changes the way that `rungame` and `initgame` work so that a programmer can run their game with the command `julia game.jl` instead of `rungame("game.jl")`. This approach allows file inclusion and does not conflict with the way games are currently run. All existing games will work as they are now. This new approach does require the user to import `GameZero`, `Colors`, and `GameZero.draw` at the script's beginning, and put `rungame()` at the end of the script if they want to run the game in the new way. This PR includes the functionality of #22 and resolves #9.