### PR TITLE
Pass mandatory argument to `initgame` in tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,16 +3,16 @@ using Test
 
 @testset "basic" begin
     global g
-    @test_nowarn begin 
-        g = GameZero.initgame(joinpath("..","example","BasicGame","basic.jl"))
+    @test_nowarn begin
+        g = GameZero.initgame(joinpath("..","example","BasicGame","basic.jl"), true)
         GameZero.quitSDL(g)
     end
-    
+
 end
 
 @testset "basic2" begin
-    @test_nowarn begin 
-        g = GameZero.initgame(joinpath("..","example","BasicGame","basic2.jl"))
+    @test_nowarn begin
+        g = GameZero.initgame(joinpath("..","example","BasicGame","basic2.jl"), true)
         GameZero.quitSDL(g)
     end
 end


### PR DESCRIPTION
PR #38 added a new mandatory argument to `initgame`, which however isn't used in
tests.