### PR TITLE
Fix Actor docstring

### DIFF
--- a/src/actor.jl
+++ b/src/actor.jl
@@ -12,7 +12,7 @@ end
 """
 `Actor(image::String)`
 
-Creates an Actor with the image given, which must be located in the `image` subdirectory.
+Creates an Actor with the image given, which must be located in the `images` subdirectory.
 """
 function Actor(image::String; kv...)
     sf=image_surface(image)


### PR DESCRIPTION
Images must be located in the "images" subdirectory instead. Tested by renaming my folder to "image" and having it throw an error.