### PR TITLE
[WIP] Adding documentation for frequently used undocumented functions

### DIFF
--- a/src/actor.jl
+++ b/src/actor.jl
@@ -25,6 +25,11 @@ function Actor(image::String; kv...)
     return a
 end
 
+"""
+    TextActor(text::String, font_name::String; font_size=24, color=Int[255,255,0,255])
+
+Creates an actor with text rendered using font font_name. Font should be located in fonts directory. 
+"""
 function TextActor(text::String, font_name::String; font_size=24, color=Int[255,255,0,255], kv...)
     font = SDL2.TTF_OpenFont(file_path(font_name, :fonts), font_size)
     sf = SDL2.TTF_RenderText_Blended(font, text, SDL2.Color(color...))

--- a/src/screen.jl
+++ b/src/screen.jl
@@ -16,6 +16,12 @@ end
 
 abstract type Geom end
 
+"""
+`Rect(x::Int,y::Int,w::Int,h::Int)`
+`Rect(x::Tuple, y::Tuple)`
+
+Creates an actor representing a rectangle.
+"""
 mutable struct Rect <: Geom
     x::Int
     y::Int
@@ -27,6 +33,12 @@ Rect(x::Tuple, y::Tuple) = Rect(x[1], x[2], y[1], y[2])
 import Base:+
 +(r::Rect, t::Tuple{T,T}) where T <: Number = Rect(Int(r.x+t[1]), Int(r.y+t[2]), r.h, r.w)
 
+"""
+`Line(x1::Int, y1::Int, x2::Int, y2::Int)`
+`Line(x::Tuple, y::Tuple)`
+
+Creates an actor representing a line. 
+"""
 mutable struct Line <: Geom  
     x1::Int
     y1::Int

--- a/src/timer.jl
+++ b/src/timer.jl
@@ -139,20 +139,42 @@ function tick(x::ContingentScheduled, elapsed, s=scheduler[])
     end
 end
 
+"""
+    schedule_once(f::Function, interval)
+
+Takes a function and an interval in seconds, and sets the function to run after that interval.
+"""
 function schedule_once(f::Function, interval)
     t = elapsed(scheduler[])
     push!(scheduler[], OnceScheduled(WeakRef(f), t+interval*1e9) )
     @debug "Added Single Schedule" f
 end
 
+"""
+    schedule_unique(f::Function, interval)
+
+Takes a function and an interval in seconds, and sets the function to run after that interval only if the same function handle was not previously set.
+"""
 function schedule_unique(f::Function, interval)
     filter(WeakRef(f), scheduler)
     push!(scheduler[], OnceScheduled(WeakRef(f), elapsed(scheduler[])+interval*1e9) )
     @debug "Added Unique Schedule" f
 end
 
+"""
+    schedule_interval(f::Function, interval, first_interval=interval)
+
+Takes a function handle and time in seconds, and sets the function to run after that interval. 
+Optional third argument first_interval can be passed to wait for that amount of time before first execution.
+"""
 function schedule_interval(f::Function, interval, first_interval=interval)
      push!(scheduler[], RepeatScheduled(WeakRef(f), elapsed(scheduler[])+first_interval*1e9), interval*1e9 )
      @debug "Added Repeated Schedule" f
 end
+
+"""
+    unschedule(f::Function)
+
+Removes a function from the schedule. 
+"""
 unschedule(f::Function) = filter!(WeakRef(f), scheduler[])


### PR DESCRIPTION
I was looking through the API page and it seems like documentation is missing for some frequently used functions. I've added docstrings there, but I don't know if that will make it automatically appear in the generated doc. 

If you have in mind any other documentations requests I can lump it in with this PR. 